### PR TITLE
Add Confirmation Prompt for Potentially Harmful Task Removals

### DIFF
--- a/tasksel.pl
+++ b/tasksel.pl
@@ -651,6 +651,10 @@ sub usage {
 });
 }
 
+my @harmful_cmd = ("lamp-server", "mail-server", "print-server", "kde-desktop", "gnome-desktop", "xfce-desktop", "lxde-desktop", "cinnamon-desktop", "mate-desktop", "web-server", 
+"database-server", "file-server", "dns-server", "ssh-server", "samba-server", "lamp-stack", "lemp-stack", "audio-workstation", "video-workstation", "graphics-workstation", "robotics-suite", 
+"virtual-machine-host", "kubernetes-cluster", "docker-container-runtime", "development-tools", "educational-desktop", "scientific-desktop", "security-desktop")
+
 # Process command line options and return them in a hash.
 sub getopts {
 	my %ret;
@@ -669,6 +673,19 @@ sub getopts {
 		}
 		elsif ($cmd eq "remove") {
 			$ret{cmd_remove} = \@ARGV;
+   			foreach my $task (@{$ret{cmd_remove}}){
+      				if (grep {$_ eq $task} @harmful_cmd){
+	  				print "Warning: Removing $task may harm your system.\n";
+					print "Do you want to continue with the removal? (Y/N): ";
+     					my $response = <STDIN>;
+	  				chomp $response;
+       					if (lc($response) ne 'y'){
+	    					print "Removal of $task canceled by the user.\n";
+	  					exit;
+					}
+     					last;
+				}
+			}
 		}
 		else {
 			usage();


### PR DESCRIPTION
This commit introduces a new safety feature in the 'tasksel' tool to prevent accidental removal of critical system tasks. A confirmation prompt is added to the removal process for tasks that are identified as potentially harmful.

Key Changes:
- Defined a list of critical tasks (`@harmful_cmd`) that are considered dangerous to remove. This list can be modified to include any task that is crucial for system stability.
- Modified the `getopts` function to include a check against this list when processing a `remove` command. If the command involves any of these harmful tasks, the user is prompted to confirm their intention.
- Implemented a confirmation prompt that requires explicit user approval (input 'Y') to proceed with the removal. If the user responds with 'N' or any other input, the script immediately exits, thereby stopping the removal process.
- This feature adds an extra layer of protection against inadvertent system damage, especially for users who might not be fully aware of the consequences of removing certain tasks.

Testing:
- Extensive testing is recommended to ensure that the new confirmation prompt behaves correctly under various scenarios and does not disrupt the intended functionality of 'tasksel'.
- The list of harmful commands should be reviewed and updated as needed based on the specific use case and system requirements.

This change aims to enhance the usability and safety of 'tasksel', particularly in environments where accidental removal of critical tasks could lead to significant system issues.